### PR TITLE
Shorten the initial session loading view

### DIFF
--- a/apps/frontend/src/widgets/dashboard/dashboard.tsx
+++ b/apps/frontend/src/widgets/dashboard/dashboard.tsx
@@ -32,7 +32,7 @@ export const RestaurantDashboard = () => {
   if (authLoading) {
     return (
       <div className="!p-4 !pb-[calc(env(safe-area-inset-bottom)+1rem)] sm:!p-12">
-        Checking session...
+        <span className="sr-only">Checking session...</span>
       </div>
     );
   }


### PR DESCRIPTION
This keeps the initial session check message available to screen readers while preventing the long text from visibly stretching the first dashboard view. I verified the frontend still builds successfully with pnpm --filter mealer-frontend build.