### PR TITLE
Fix session loading message layout

### DIFF
--- a/apps/frontend/src/widgets/dashboard/dashboard.tsx
+++ b/apps/frontend/src/widgets/dashboard/dashboard.tsx
@@ -31,8 +31,10 @@ export const RestaurantDashboard = () => {
 
   if (authLoading) {
     return (
-      <div className="!p-4 !pb-[calc(env(safe-area-inset-bottom)+1rem)] sm:!p-12">
-        Checking session...
+      <div className="flex min-h-24 items-center justify-center !p-4 !pb-[calc(env(safe-area-inset-bottom)+1rem)] sm:min-h-full sm:!p-12">
+        <span className="text-sm text-gray-600" aria-live="polite">
+          Checking session...
+        </span>
       </div>
     );
   }


### PR DESCRIPTION
## Summary\n- center the initial session-checking message within the dashboard area\n- reduce the loading copy size so it does not dominate the initial view\n- expose the loading status politely to assistive technologies\n\n## Verification\n- pnpm exec eslint apps/frontend/src/widgets/dashboard/dashboard.tsx\n- pnpm --dir apps/frontend build\n\nNote: `pnpm --dir apps/frontend lint` currently fails before linting this change because the generated route tree is included without type-aware parser services. The changed file passes ESLint directly.